### PR TITLE
fix to compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.0.0)
 
 
 # 3rd party modules
@@ -56,6 +56,9 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	message("-- Assuming the GNU compiler family")
 	set(COMPILER_FAMILY "gcc")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+	message("-- Assuming the Clang compiler family")
+	set(COMPILER_FAMILY "clang")
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
 	message("-- Assuming the Clang compiler family")
 	set(COMPILER_FAMILY "clang")
 else()

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_COLOR_MAKEFILE ON)
 project(vata)
 
 set(vata_compiler_add_flags_list
-  -std=c++0x
+  -std=c++17
   -pedantic-errors
 #  -DOPT_AC
   -DCACHE_AC
@@ -21,7 +21,7 @@ set(vata_compiler_add_flags_list
   -Woverloaded-virtual
   -Wold-style-cast
   -fdiagnostics-show-option
-  -march=native
+  # -march=native
 )
 
 foreach(param ${vata_compiler_add_flags_list})

--- a/include/vata/util/aut_description.hh
+++ b/include/vata/util/aut_description.hh
@@ -17,8 +17,6 @@
 #include <vata/util/triple.hh>
 #include <vata/util/two_way_dict.hh>
 
-using namespace std;
-
 namespace VATA
 {
 	namespace Util
@@ -28,7 +26,7 @@ namespace VATA
 }
 
 struct CompareSymbolName {
-    bool operator()(const vector<int> &lhs, const vector<int> &rhs) const {
+    bool operator()(const std::vector<int> &lhs, const std::vector<int> &rhs) const {
         if (lhs.size() < rhs.size())
             return true;
         else if (lhs.size() > rhs.size())
@@ -42,14 +40,14 @@ struct VATA::Util::TreeAutomata
 {
 public:   // data types
     typedef int State;
-	typedef vector<State> StateVector;
-	typedef set<State> StateSet;
+	typedef std::vector<State> StateVector;
+	typedef std::set<State> StateSet;
 
-	typedef vector<int> Symbol;
-    typedef map<Symbol, map<StateVector, StateSet>, CompareSymbolName> TransitionMap;
+	typedef std::vector<int> Symbol;
+    typedef std::map<Symbol, std::map<StateVector, StateSet>, CompareSymbolName> TransitionMap;
 
 public:   // data members
-	string name;
+		std::string name;
     StateSet finalStates;
     int stateNum, qubitNum;
 	TransitionMap transitions;
@@ -89,9 +87,9 @@ public:   // methods
 			(transitions == rhs.transitions);
 	}
 
-	string ToString() const
+	std::string ToString() const
 	{
-		string result;
+		std::string result;
 		result += "name: " + name + "\n";
 		result += "number of states: " + Convert::ToString(stateNum) + "\n";
 		result += "final states: " + Convert::ToString(finalStates) + "\n";
@@ -106,7 +104,7 @@ public:   // methods
 
 private:
     void remove_useless();
-    bool is_same_partition(const vector<int> &state_to_partition_id, State a, State b);
+    bool is_same_partition(const std::vector<int> &state_to_partition_id, State a, State b);
     TreeAutomata binary_operation(const TreeAutomata &o, bool add);
     void swap_forward(const int k);
     void swap_backward(const int k);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,8 +15,8 @@ set(vata_cxx_compiler_flags
   -Wall
   -Wfloat-equal
   -fdiagnostics-show-option
-  -march=native
-  -std=c++11
+  # -march=native
+  -std=c++17
   -Wctor-dtor-privacy
   -Weffc++
   -fPIC

--- a/src/timbuk_parser-nobison.cc
+++ b/src/timbuk_parser-nobison.cc
@@ -31,11 +31,11 @@ static std::string trim(const std::string& str)
 
 	// trim from start
 	result.erase(result.begin(), std::find_if(result.begin(), result.end(),
-		std::not1(std::ptr_fun<int, int>(std::isspace))));
+		[](int ch) {return !std::isspace(ch);}));
 
 	// trim from end
 	result.erase(std::find_if(result.rbegin(), result.rend(),
-		std::not1(std::ptr_fun<int, int>(std::isspace))).base(), result.end());
+		[](int ch) {return !std::isspace(ch);}).base(), result.end());
 
 	return result;
 }
@@ -73,7 +73,7 @@ static std::vector<std::string> split_delim(
 static std::string read_word(std::string& str)
 {
 	std::string::iterator end(std::find_if(str.begin(), str.end(),
-		std::ptr_fun<int, int>(std::isspace)));
+		[](int ch) { return std::isspace(ch);}));
 	std::string result(str.begin(), end);
 
 	str.erase(str.begin(), end);
@@ -87,7 +87,7 @@ static std::string read_word(std::string& str)
  */
 static bool contains_whitespace(const std::string& str)
 {
-	return str.end() != std::find_if(str.begin(), str.end(), std::ptr_fun<int, int>(std::isspace));
+	return str.end() != std::find_if(str.begin(), str.end(), [](int ch) { return std::isspace(ch);});
 }
 
 
@@ -117,9 +117,9 @@ static std::pair<std::string, int> parse_colonned_token(std::string str)
 /**
  * @brief  Parse a string with Timbuk definition of an automaton
  */
-vector<int> symbol_converter(const std::string& str)
+std::vector<int> symbol_converter(const std::string& str)
 {
-    vector<int> temp;
+	std::vector<int> temp;
     if (str[0] == '[') {
         for (int i=1; i<static_cast<int>(str.length()); i++) {
             size_t j = str.find(',', i);
@@ -340,7 +340,7 @@ static TreeAutomata parse_timbuk(const std::string& str)
 
     for (const auto &kv : result.transitions) {
         if (kv.first.size() < 5)
-            result.qubitNum = max(result.qubitNum, kv.first[0]);
+            result.qubitNum = std::max(result.qubitNum, kv.first[0]);
     }
 
 	return result;

--- a/src/util/aut_operation.cc
+++ b/src/util/aut_operation.cc
@@ -1,15 +1,17 @@
 #include <vata/util/aut_description.hh>
 
+#include <numeric>
+
 template <class T>
-int findIndex(const vector<T> &arr, T item) {
+int findIndex(const std::vector<T> &arr, T item) {
     for (int i = 0; i < static_cast<int>(arr.size()); ++i) {
         if (arr[i] == item)
             return i;
     }
-    __throw_out_of_range("findIndex");
+		std::__throw_out_of_range("findIndex");
 }
 
-bool VATA::Util::TreeAutomata::is_same_partition(const vector<int> &state_to_partition_id, State a, State b) {
+bool VATA::Util::TreeAutomata::is_same_partition(const std::vector<int> &state_to_partition_id, State a, State b) {
     assert (state_to_partition_id[a] == state_to_partition_id[b]);
     for (const auto &f : transitions) { // for all functions
         int arity = f.second.begin()->first.size();
@@ -35,12 +37,12 @@ bool VATA::Util::TreeAutomata::is_same_partition(const vector<int> &state_to_par
                 }
                 if (resultA != resultB) return false;
                 if (i+1 < arity)
-                    swap(sv[i], sv[i+1]);
+                    std::swap(sv[i], sv[i+1]);
             }
             for (int i=0; i<arity-1; i++) {
-                swap(sv[i], sv[i+1]);
+							std::swap(sv[i], sv[i+1]);
             }
-            
+
             overflow = (arity == 1);
             if (!overflow) { // arity > 1
                 sv[1]++;
@@ -62,7 +64,7 @@ bool VATA::Util::TreeAutomata::is_same_partition(const vector<int> &state_to_par
 }
 
 void VATA::Util::TreeAutomata::determinize() {
-    vector<StateSet> composite_set_id;
+	std::vector<StateSet> composite_set_id;
     TransitionMap transitions_new;
 
     /*******************************************************************/
@@ -167,7 +169,7 @@ void VATA::Util::TreeAutomata::determinize() {
 void VATA::Util::TreeAutomata::minimize() { // only for already determinized automata!
     /*******************************************************************/
     // Part 1: Partition states according to final states.
-    vector<StateVector> partition;
+		std::vector<StateVector> partition;
     partition.push_back({}); // non-final states
     partition.push_back({}); // final states
     for (int i=0; i<stateNum; i++) { // TODO: can be optimized
@@ -180,18 +182,18 @@ void VATA::Util::TreeAutomata::minimize() { // only for already determinized aut
 
     /*******************************************************************/
     // Part 2: Main loop of partition refinement.
-    vector<int> state_to_partition_id;
+		std::vector<int> state_to_partition_id;
     bool changed;
     do {
         changed = false;
-        vector<StateVector> new_partition; // 有 .clear 的效果。
-        state_to_partition_id = vector<int>(stateNum); // 有 .clear 的效果。
+				std::vector<StateVector> new_partition; // 有 .clear 的效果。
+        state_to_partition_id = std::vector<int>(stateNum); // 有 .clear 的效果。
         for (unsigned i=0; i<partition.size(); i++) {
             for (const auto &s : partition[i])
                 state_to_partition_id[s] = i;
         }
         for (const auto &cell : partition) { // original cell
-            map<State, StateVector> refined; // 有 .clear 的效果。
+					std::map<State, StateVector> refined; // 有 .clear 的效果。
             for (const auto &s : cell) { // state
                 bool different_from_others = true;
                 for (auto &new_cell : refined) { // check if s belongs to some refined cell
@@ -250,10 +252,10 @@ void VATA::Util::TreeAutomata::minimize() { // only for already determinized aut
 
 void VATA::Util::TreeAutomata::remove_useless() { // only for already determinized automata!
     bool changed;
-    vector<bool> traversed(stateNum, false);
+		std::vector<bool> traversed(stateNum, false);
     TransitionMap transitions_remaining = transitions;
     TransitionMap transitions_mother;
-    
+
     /*******************
      * Part 1: Bottom-Up
      *******************/
@@ -290,7 +292,7 @@ void VATA::Util::TreeAutomata::remove_useless() { // only for already determiniz
     /******************
      * Part 2: Top-Down
      ******************/
-    traversed = vector<bool>(stateNum, false);
+    traversed = std::vector<bool>(stateNum, false);
     for (const auto &s : finalStates)
         traversed[s] = true;
     transitions_remaining = transitions;
@@ -323,7 +325,7 @@ void VATA::Util::TreeAutomata::remove_useless() { // only for already determiniz
      * Part 3: Renumbering
      *********************/
     TransitionMap transitions_new;
-    map<int, int> stateOldToNew;
+		std::map<int, int> stateOldToNew;
     for (const auto &t : transitions) {
         for (const auto &in_out : t.second) {
             StateVector sv;
@@ -427,7 +429,7 @@ void VATA::Util::TreeAutomata::omega_multiplication() {
 }
 
 void VATA::Util::TreeAutomata::divide_by_the_square_root_of_two() {
-    vector<StateVector> to_be_removed;
+		std::vector<StateVector> to_be_removed;
     TransitionMap to_be_inserted;
     for (const auto &t : transitions) {
         if (t.first.size() == 5) {
@@ -492,7 +494,7 @@ void VATA::Util::TreeAutomata::branch_restriction(int k, bool positive_has_value
             }
         }
     }
-    
+
     determinize();
     minimize();
 }
@@ -507,9 +509,9 @@ void VATA::Util::TreeAutomata::semi_determinize() {
             sv.push_back(t.first[0]);
             for (const auto &in_out : t.second) {
                 sv.push_back(counter++);
-                map<StateVector, StateSet> value;
+								std::map<StateVector, StateSet> value;
                 value.insert(in_out);
-                transitions.insert(make_pair(sv, value)); // modify
+                transitions.insert(std::make_pair(sv, value)); // modify
                 sv.pop_back();
             }
         }
@@ -540,7 +542,7 @@ VATA::Util::TreeAutomata VATA::Util::TreeAutomata::binary_operation(const TreeAu
     result.name = name;
     result.qubitNum = qubitNum;
     result.stateNum *= o.stateNum;
-    
+
     for (const auto &fs1 : finalStates)
         for (const auto &fs2 : o.finalStates) {
             result.finalStates.insert(fs1 * o.stateNum + fs2);
@@ -559,7 +561,7 @@ VATA::Util::TreeAutomata VATA::Util::TreeAutomata::binary_operation(const TreeAu
         if (it2 == o.transitions.end()) continue;
         // assert(it->second.size() == 1); // both sources contain the unique I/O
         // assert(it2->second.size() == 1); // i.e., map<StateVector, StateSet> is singleton.
-        map<StateVector, StateSet> m;
+				std::map<StateVector, StateSet> m;
         for (auto itt = it->second.begin(); itt != it->second.end(); itt++)
             for (auto itt2 = it2->second.begin(); itt2 != it2->second.end(); itt2++) {
                 StateVector sv;
@@ -645,7 +647,7 @@ VATA::Util::TreeAutomata VATA::Util::TreeAutomata::classical(int n) {
 
 void VATA::Util::TreeAutomata::swap_forward(const int k) {
     for (int next_k=k+1; next_k<=qubitNum; next_k++) {
-        map<State, vector<pair<Symbol, StateVector>>> svsv;
+				std::map<State, std::vector<std::pair<Symbol, StateVector>>> svsv;
         for (const auto &t : transitions) {
             if (t.first.size() < 5 && t.first[0] == next_k) {
                 assert(t.first.size() <= 2);
@@ -659,7 +661,7 @@ void VATA::Util::TreeAutomata::swap_forward(const int k) {
                 // }
             }
         }
-        vector<Symbol> to_be_removed2;
+				std::vector<Symbol> to_be_removed2;
         TransitionMap to_be_removed, to_be_inserted;
         for (const auto &t : transitions) {
             if (t.first.size() < 5 && t.first[0] == k) {
@@ -704,7 +706,7 @@ void VATA::Util::TreeAutomata::swap_forward(const int k) {
 
 void VATA::Util::TreeAutomata::swap_backward(const int k) {
     for (int next_k=qubitNum; next_k>k; next_k--) {
-        map<State, vector<pair<Symbol, StateVector>>> svsv;
+			std::map<State, std::vector<std::pair<Symbol, StateVector>>> svsv;
         for (const auto &t : transitions) {
             auto &symbol = t.first;
             auto &in_outs = t.second;
@@ -723,7 +725,7 @@ void VATA::Util::TreeAutomata::swap_backward(const int k) {
                 }
             }
         }
-        vector<Symbol> to_be_removed2;
+				std::vector<Symbol> to_be_removed2;
         TransitionMap to_be_removed, to_be_inserted;
         for (const auto &t : transitions) {
             if (t.first.size() < 5 && t.first[0] == next_k) {
@@ -774,7 +776,7 @@ void VATA::Util::TreeAutomata::swap_backward(const int k) {
 void VATA::Util::TreeAutomata::value_restriction(int k, bool branch) {
     swap_forward(k);
     TransitionMap to_be_inserted;
-    vector<Symbol> to_be_removed;
+		std::vector<Symbol> to_be_removed;
     for (const auto &t : transitions) {
         if (t.first.size() < 5 && t.first[0] == k) {
             to_be_removed.push_back(t.first);
@@ -801,7 +803,7 @@ void VATA::Util::TreeAutomata::value_restriction(int k, bool branch) {
 }
 
 void VATA::Util::TreeAutomata::fraction_simplication() {
-    vector<StateVector> to_be_removed;
+	std::vector<StateVector> to_be_removed;
     TransitionMap to_be_inserted;
     for (const auto &t : transitions) {
         if (t.first.size() == 5) {
@@ -809,7 +811,7 @@ void VATA::Util::TreeAutomata::fraction_simplication() {
             StateVector sv = t.first;
             int gcd = abs(t.first[0]);
             for (int i=1; i<4; i++)
-                gcd = __gcd(gcd, abs(t.first[i]));
+                gcd = std::gcd(gcd, abs(t.first[i]));
             if (gcd > 0) {
                 for (int i=0; i<4; i++)
                     sv[i] /= gcd;

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 2.8.2)
 project(unit_tests)
 
 set(compiler_flags_list
-  -std=c++0x
+  -std=c++17
   -pedantic-errors
   -Wextra
   -Wall
@@ -14,7 +14,7 @@ set(compiler_flags_list
   -Woverloaded-virtual
   -Wold-style-cast
   -fdiagnostics-show-option
-  -march=native
+  # -march=native
 )
 
 set(compiler_flags "")

--- a/unit_tests/explicit_tree_aut_test.cc
+++ b/unit_tests/explicit_tree_aut_test.cc
@@ -19,35 +19,71 @@
 #define BOOST_TEST_MODULE AutType
 #include <boost/test/unit_test.hpp>
 
-const string &path_to_VATA = "/home/alan23273850/libvata/build/cli/vata";
+std::string gpath_to_VATA = "";
 int size = 5; // the number of qubits.
+
+/** returns the path to VATA executable */
+const std::string& get_vata_path()
+{
+	// is it cached?
+	if (!gpath_to_VATA.empty()) return gpath_to_VATA;
+
+	// not cached, get it from ENV
+	const char* path = std::getenv("VATA_PATH");
+	if (nullptr == path) {
+		throw std::runtime_error("Cannot find environment variable VATA_PATH");
+	}
+
+	gpath_to_VATA = path;
+	return gpath_to_VATA;
+}
+
+
+/** checks inclusion of two TAs */
+bool check_inclusion(const std::string& lhsPath, const std::string& rhsPath)
+{
+	std::string aux;
+	VATA::Util::ShellCmd(get_vata_path() + " incl " + lhsPath + " " + rhsPath, aux);
+	return (aux == "1\n");
+}
+
+/** checks language equivalence of two TAs */
+bool check_equal(const std::string& lhsPath, const std::string& rhsPath)
+{
+	return check_inclusion(lhsPath, rhsPath) && check_inclusion(rhsPath, lhsPath);
+}
+
+bool check_equal_aut(const VATA::Util::TreeAutomata& lhs, const VATA::Util::TreeAutomata& rhs)
+{
+	VATA::Serialization::TimbukSerializer serializer;
+	std::ofstream fileLhs("/tmp/automata1.txt");
+	fileLhs << serializer.Serialize(lhs);
+	fileLhs.close();
+
+	std::ofstream fileRhs("/tmp/automata2.txt");
+	fileRhs << serializer.Serialize(rhs);
+	fileRhs.close();
+
+	return check_equal("/tmp/automata1.txt", "/tmp/automata2.txt");
+}
+
 
 BOOST_AUTO_TEST_CASE(X_gate_twice_to_identity)
 {
     int n = size/2 + 1;
     VATA::Serialization::TimbukSerializer serializer;
     for (const auto &before : {VATA::Util::TreeAutomata::uniform(n), VATA::Util::TreeAutomata::classical(n)}) {
-        ofstream file1("/tmp/automata1.txt");
-        file1 << serializer.Serialize(before);
-        file1.close();
 
         for (auto t : {1, n/2+1, n}) {
             VATA::Util::TreeAutomata after = before;
             for (int i=0; i<2; i++) {
                 after.X(t);
 
-                ofstream file2("/tmp/automata2.txt");
-                file2 << serializer.Serialize(after);
-                file2.close();
-
-                string include1, include2;
-                VATA::Util::ShellCmd(path_to_VATA + " incl /tmp/automata1.txt /tmp/automata2.txt", include1);
-                VATA::Util::ShellCmd(path_to_VATA + " incl /tmp/automata2.txt /tmp/automata1.txt", include2);
-
                 if (i < 2-1) {}
                     // BOOST_REQUIRE_MESSAGE(!(include1=="1\n" && include2=="1\n"), "");
-                else
-                    BOOST_REQUIRE_MESSAGE(include1=="1\n" && include2=="1\n", "");
+                else {
+                    BOOST_REQUIRE_MESSAGE(check_equal_aut(before, after), "");
+								}
             }
         }
     }
@@ -58,27 +94,18 @@ BOOST_AUTO_TEST_CASE(Y_gate_twice_to_identity)
     int n = size/2 + 1;
     VATA::Serialization::TimbukSerializer serializer;
     for (const auto &before : {VATA::Util::TreeAutomata::uniform(n), VATA::Util::TreeAutomata::classical(n)}) {
-        ofstream file1("/tmp/automata1.txt");
-        file1 << serializer.Serialize(before);
-        file1.close();
 
         for (auto t : {1, n/2+1, n}) {
             VATA::Util::TreeAutomata after = before;
             for (int i=0; i<2; i++) {
                 after.Y(t);
 
-                ofstream file2("/tmp/automata2.txt");
-                file2 << serializer.Serialize(after);
-                file2.close();
-
-                string include1, include2;
-                VATA::Util::ShellCmd(path_to_VATA + " incl /tmp/automata1.txt /tmp/automata2.txt", include1);
-                VATA::Util::ShellCmd(path_to_VATA + " incl /tmp/automata2.txt /tmp/automata1.txt", include2);
-
-                if (i < 2-1)
-                    BOOST_REQUIRE_MESSAGE(!(include1=="1\n" && include2=="1\n"), "");
-                else
-                    BOOST_REQUIRE_MESSAGE(include1=="1\n" && include2=="1\n", "");
+                if (i < 2-1) {
+                    BOOST_REQUIRE_MESSAGE(!check_equal_aut(before, after), "");
+								}
+                else {
+                    BOOST_REQUIRE_MESSAGE(check_equal_aut(before, after), "");
+								}
             }
         }
     }
@@ -90,25 +117,15 @@ BOOST_AUTO_TEST_CASE(Z_gate_twice_to_identity)
     for (const auto &before : {VATA::Util::TreeAutomata::uniform(size), VATA::Util::TreeAutomata::classical(size)}) {
         VATA::Util::TreeAutomata after = before;
 
-        ofstream file1("/tmp/automata1.txt");
-        file1 << serializer.Serialize(before);
-        file1.close();
-
         for (int i=0; i<2; i++) {
             after.Z(size/2);
 
-            ofstream file2("/tmp/automata2.txt");
-            file2 << serializer.Serialize(after);
-            file2.close();
-
-            string include1, include2;
-            VATA::Util::ShellCmd(path_to_VATA + " incl /tmp/automata1.txt /tmp/automata2.txt", include1);
-            VATA::Util::ShellCmd(path_to_VATA + " incl /tmp/automata2.txt /tmp/automata1.txt", include2);
-
-            if (i < 2-1)
-                BOOST_REQUIRE_MESSAGE(!(include1=="1\n" && include2=="1\n"), "");
-            else
-                BOOST_REQUIRE_MESSAGE(include1=="1\n" && include2=="1\n", "");
+            if (i < 2-1) {
+                BOOST_REQUIRE_MESSAGE(!check_equal_aut(before, after), "");
+						}
+            else {
+                BOOST_REQUIRE_MESSAGE(check_equal_aut(before, after), "");
+						}
         }
     }
 }
@@ -118,27 +135,18 @@ BOOST_AUTO_TEST_CASE(H_gate_twice_to_identity)
     int n = size/2 + 1;
     VATA::Serialization::TimbukSerializer serializer;
     for (const auto &before : {VATA::Util::TreeAutomata::uniform(n), VATA::Util::TreeAutomata::classical(n)}) {
-        ofstream file1("/tmp/automata1.txt");
-        file1 << serializer.Serialize(before);
-        file1.close();
 
         for (auto t : {1, n/2+1, n}) {
             VATA::Util::TreeAutomata after = before;
             for (int i=0; i<2; i++) {
-                after.H(t);
+								after.H(t);
 
-                ofstream file2("/tmp/automata2.txt");
-                file2 << serializer.Serialize(after);
-                file2.close();
-
-                string include1, include2;
-                VATA::Util::ShellCmd(path_to_VATA + " incl /tmp/automata1.txt /tmp/automata2.txt", include1);
-                VATA::Util::ShellCmd(path_to_VATA + " incl /tmp/automata2.txt /tmp/automata1.txt", include2);
-
-                if (i < 2-1)
-                    BOOST_REQUIRE_MESSAGE(!(include1=="1\n" && include2=="1\n"), "");
-                else
-                    BOOST_REQUIRE_MESSAGE(include1=="1\n" && include2=="1\n", "");
+								if (i < 2-1) {
+										BOOST_REQUIRE_MESSAGE(!check_equal_aut(before, after), "");
+								}
+								else {
+										BOOST_REQUIRE_MESSAGE(check_equal_aut(before, after), "");
+								}
             }
         }
     }
@@ -150,25 +158,15 @@ BOOST_AUTO_TEST_CASE(S_gate_fourth_to_identity)
     for (const auto &before : {VATA::Util::TreeAutomata::uniform(size), VATA::Util::TreeAutomata::classical(size)}) {
         VATA::Util::TreeAutomata after = before;
 
-        ofstream file1("/tmp/automata1.txt");
-        file1 << serializer.Serialize(before);
-        file1.close();
-
         for (int i=0; i<4; i++) {
             after.S(size/2);
 
-            ofstream file2("/tmp/automata2.txt");
-            file2 << serializer.Serialize(after);
-            file2.close();
-
-            string include1, include2;
-            VATA::Util::ShellCmd(path_to_VATA + " incl /tmp/automata1.txt /tmp/automata2.txt", include1);
-            VATA::Util::ShellCmd(path_to_VATA + " incl /tmp/automata2.txt /tmp/automata1.txt", include2);
-
-            if (i < 4-1)
-                BOOST_REQUIRE_MESSAGE(!(include1=="1\n" && include2=="1\n"), "");
-            else
-                BOOST_REQUIRE_MESSAGE(include1=="1\n" && include2=="1\n", "");
+            if (i < 4-1) {
+								BOOST_REQUIRE_MESSAGE(!check_equal_aut(before, after), "");
+						}
+						else {
+								BOOST_REQUIRE_MESSAGE(check_equal_aut(before, after), "");
+						}
         }
     }
 }
@@ -179,25 +177,15 @@ BOOST_AUTO_TEST_CASE(T_gate_eighth_to_identity)
     for (const auto &before : {VATA::Util::TreeAutomata::uniform(size), VATA::Util::TreeAutomata::classical(size)}) {
         VATA::Util::TreeAutomata after = before;
 
-        ofstream file1("/tmp/automata1.txt");
-        file1 << serializer.Serialize(before);
-        file1.close();
-
         for (int i=0; i<8; i++) {
             after.T(size/2);
 
-            ofstream file2("/tmp/automata2.txt");
-            file2 << serializer.Serialize(after);
-            file2.close();
-
-            string include1, include2;
-            VATA::Util::ShellCmd(path_to_VATA + " incl /tmp/automata1.txt /tmp/automata2.txt", include1);
-            VATA::Util::ShellCmd(path_to_VATA + " incl /tmp/automata2.txt /tmp/automata1.txt", include2);
-
-            if (i < 8-1)
-                BOOST_REQUIRE_MESSAGE(!(include1=="1\n" && include2=="1\n"), "");
-            else
-                BOOST_REQUIRE_MESSAGE(include1=="1\n" && include2=="1\n", "");
+            if (i < 8-1) {
+								BOOST_REQUIRE_MESSAGE(!check_equal_aut(before, after), "");
+						}
+						else {
+								BOOST_REQUIRE_MESSAGE(check_equal_aut(before, after), "");
+						}
         }
     }
 }
@@ -208,25 +196,15 @@ BOOST_AUTO_TEST_CASE(CZ_gate_twice_to_identity)
     for (const auto &before : {VATA::Util::TreeAutomata::uniform(size), VATA::Util::TreeAutomata::classical(size)}) {
         VATA::Util::TreeAutomata after = before;
 
-        ofstream file1("/tmp/automata1.txt");
-        file1 << serializer.Serialize(before);
-        file1.close();
-
         for (int i=0; i<2; i++) {
             after.CZ(size*2/3, size/3);
 
-            ofstream file2("/tmp/automata2.txt");
-            file2 << serializer.Serialize(after);
-            file2.close();
-
-            string include1, include2;
-            VATA::Util::ShellCmd(path_to_VATA + " incl /tmp/automata1.txt /tmp/automata2.txt", include1);
-            VATA::Util::ShellCmd(path_to_VATA + " incl /tmp/automata2.txt /tmp/automata1.txt", include2);
-
-            if (i < 2-1)
-                BOOST_REQUIRE_MESSAGE(!(include1=="1\n" && include2=="1\n"), "");
-            else
-                BOOST_REQUIRE_MESSAGE(include1=="1\n" && include2=="1\n", "");
+            if (i < 2-1) {
+								BOOST_REQUIRE_MESSAGE(!check_equal_aut(before, after), "");
+						}
+						else {
+								BOOST_REQUIRE_MESSAGE(check_equal_aut(before, after), "");
+						}
         }
     }
 }


### PR DESCRIPTION
A few things:
1. it's considered a bad practice to declare `using namespace std` in a source file (especially in a header file!) - the current namespace gets cluttered with many names from `std` (I had several collisions when trying to compile)
2. I bumped the version of C++ used to C++17 (in order to avoid issues with using the `std::gcc` function)
3. I made the code in `explicit_tree_aut_test` more structured
4. I dropped the requirements for CMake version 2.x.y
5. due to the change to C++17, I needed to change some code using `std::ptr_fun` to lambdas